### PR TITLE
Fix file locations in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,15 +27,15 @@ dist/hocr-viewer.css: sass/hocr-viewer.scss
 	$(MKDIR) dist
 	$(SASS) $< > $@
 
-dist/hocr-parser.js: LICENSE.js js/parser.js
+dist/hocr-parser.js: LICENSE.js src/lib/parser.js
 	$(MKDIR) dist
 	$(CAT_SOURCE_MAP) $^ $@
 
-dist/hocr-viewer.js: LICENSE.js js/parser.js js/viewer.js
+dist/hocr-viewer.js: LICENSE.js src/lib/parser.js src/browser/viewer.js
 	$(MKDIR) dist
 	$(CAT_SOURCE_MAP) $^ $@
 
-dist/hocr-viewer-fullscreen.js: LICENSE.js js/parser.js js/viewer.js js/fullscreen-init.js
+dist/hocr-viewer-fullscreen.js: LICENSE.js src/lib/parser.js src/browser/viewer.js src/browser/fullscreen-init.js
 	$(MKDIR) dist
 	$(CAT_SOURCE_MAP) $^ $@
 


### PR DESCRIPTION
Commit 8570f4e324d85fb3edaf9b07cf59f954e949d154 moved some files
from the js/ directory to other directories.

Update Makefile to use the new locations.

Signed-off-by: Stefan Weil <sw@weilnetz.de>