### PR TITLE
README: Use XHTML-compatible script tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See this demo document: [Demo](https://kba.github.io/hocrjs/example/426117689_04
 To add the interface to a plain hOCR file, add this line just before the closing `</body>` tag:
 
 ```html
-<script src="https://unpkg.com/hocrjs"/>
+<script src="https://unpkg.com/hocrjs"></script>
 ```
 
 ### User script


### PR DESCRIPTION
The same is used in the example
   http://kba.cloud/hocrjs/example/426117689_0459.html
and otherwise the file does not open correctly in the browser.