### PR TITLE
Don't use a fixed version number in update url

### DIFF
--- a/hocrjs/Makefile
+++ b/hocrjs/Makefile
@@ -6,8 +6,8 @@ VERSION = $(shell git describe --abbrev=0 --tags|sed -e 's/v//')
 # URL of the asset server, serving the built files and userscript
 ASSET_SERVER = https://unpkg.com/hocrjs@$(VERSION)/dist
 
-# URL of the userscript update server (defaults to ASSET_SERVER)
-UPDATE_SERVER = $(ASSET_SERVER)
+# URL of the userscript update server (will automatically redirect to latest version)
+UPDATE_SERVER = https://unpkg.com/hocrjs
 
 # Command to run a static server
 STATIC_SERVER = @python2 -m SimpleHTTPServer $(PORT)
@@ -31,7 +31,7 @@ help:
 	@echo ""
 	@echo "    VERSION        Version of the latest git tag"
 	@echo "    ASSET_SERVER   URL of the asset server, serving the built files and userscript"
-	@echo "    UPDATE_SERVER  URL of the userscript update server (defaults to ASSET_SERVER)"
+	@echo "    UPDATE_SERVER  URL of the userscript update server"
 	@echo "    STATIC_SERVER  Command to run a static server"
 	@echo "    PORT           Server port. Default: 8888"
 

--- a/vue-hocr/README.md
+++ b/vue-hocr/README.md
@@ -99,7 +99,7 @@ Clone the repository and run `make` for a list of targets:
 
     VERSION        Version of the latest git tag
     ASSET_SERVER   URL of the asset server, serving the built files and userscript
-    UPDATE_SERVER  URL of the userscript update server (defaults to ASSET_SERVER)
+    UPDATE_SERVER  URL of the userscript update server
     STATIC_SERVER  Command to run a static server
     PORT           Server port
 


### PR DESCRIPTION
The user script does currently not update automatically,
because the update url contains a fixed version number.
With a more generic url which redirects automatically
to the latest version, the updates should work.